### PR TITLE
fix: add generic type parameter to isPlainArray function

### DIFF
--- a/packages/persister/src/compare.ts
+++ b/packages/persister/src/compare.ts
@@ -63,7 +63,7 @@ export function shallowEqualObjects<T extends Record<string, any>>(
   return true
 }
 
-export function isPlainArray(value: unknown) {
+export function isPlainArray<T>(value: unknown): value is Array<T> {
   return Array.isArray(value) && value.length === Object.keys(value).length
 }
 


### PR DESCRIPTION

add a generic type parameter to isPlainArray to improve type narrowing at call sites; runtime behavior is unchanged.!